### PR TITLE
Added package version.

### DIFF
--- a/src/Mews.Fiscalization.Core/Mews.Fiscalization.Core.csproj
+++ b/src/Mews.Fiscalization.Core/Mews.Fiscalization.Core.csproj
@@ -10,6 +10,7 @@
         <PackageTags>fiscalization core</PackageTags>
         <PackageLicenseUrl>https://github.com/MewsSystems/fiscalization-core/blob/master/LICENSE</PackageLicenseUrl>
         <LangVersion>8.0</LangVersion>
+        <PackageVersion>1.0.0</PackageVersion>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     </PropertyGroup>
 


### PR DESCRIPTION
We had to add this tag in order for the publish to work, apparently, the pack command fails when targeting multiple frameworks, so for now we will keep the tag, but we might change it to build with MSBuild in the future.